### PR TITLE
Rollback a problematic solution to having variable-size soil layers

### DIFF
--- a/src/cpp/soil/soil.h
+++ b/src/cpp/soil/soil.h
@@ -22,9 +22,8 @@ Copyright (C) Leibniz Centre for Agricultural Landscape Research (ZALF)
 #include <string>
 #include <vector>
 #include <map>
+#include <functional>
 #include <iostream>
-
-#include "kj/function.h"
 
 #include "model/monica/monica_params.capnp.h"
 
@@ -33,11 +32,6 @@ Copyright (C) Leibniz Centre for Agricultural Landscape Research (ZALF)
 
 namespace Soil
 {
-
-std::function<double(double)> transformIfPercent(const json11::Json &j, const std::string &key);
-
-std::function<double(double)> transformIfNotMeters(const json11::Json &j, const std::string& key);
-
 //! @author Claas Nendel, Michael Berg 
 struct SoilParameters : public Tools::Json11Serializable
 {
@@ -89,7 +83,6 @@ struct SoilParameters : public Tools::Json11Serializable
   double vs_Soil_CN_Ratio{10.0};
   double vs_SoilMoisturePercentFC{100.0};
 
-  double thickness{0};  // layer thickness in m
 private:
   double _vs_SoilRawDensity{-1.0}; //!< [kg m-3]
   double _vs_SoilBulkDensity{-1.0}; //!< [kg m-3]
@@ -126,10 +119,8 @@ const CapillaryRiseRates& readCapillaryRiseRates();
 typedef std::vector<SoilParameters> SoilPMs;
 typedef std::shared_ptr<SoilPMs> SoilPMsPtr;
 
-std::pair<SoilPMs, Tools::Errors> createEqualSizedSoilPMs(const Tools::J11Array& jsonSoilPMs, double layerThickness = 0.1,
-                                                          int numberOfLayers = 20);
-
-std::pair<SoilPMs, Tools::Errors> createSoilPMs(const Tools::J11Array &jsonSoilPMs);
+std::pair<SoilPMs, Tools::Errors> createSoilPMs(const Tools::J11Array& jsonSoilPMs, double layerThickness = 0.1,
+                                                int numberOfLayers = 20);
 
 //! creates a concatenated string of the KA5 soil-textures making up the soil-profile with the given id
 //std::string soilProfileId2KA5Layers(const std::string& abstractDbSchema,
@@ -172,7 +163,5 @@ FcSatPwp fcSatPwpFromVanGenuchten(double sandContent,
                                   double stoneContent,
                                   double soilBulkDensity,
                                   double soilOrganicCarbon);
-
-
 
 } // namespace Soil


### PR DESCRIPTION
The issue is that multiple places in the code expect specific number, and specific meaning, of soil layers. For example: SoilTransport::fq_NTransport() fails in line:
const double NO3_u = vq_SoilNO3_aq[i + 1];

CropModule::fc_OxygenDeficiency() expects that there are at least 3 soil layers, and that layers 0, 1 and 2 are 3 layers from the top 30 cm of the soil

As a result, this code crashes for soil profiles configured to have e.g. only 1 or 2 layers defined -- but code is still incorrect (e.g. CropModule::fc_OxygenDeficiency()) even if there are more layers, as long as first 3 layers aren't 10cm each.